### PR TITLE
Fix incorrect THUMBNAIL_REG regex in scoreinfo

### DIFF
--- a/src/scoreinfo.ts
+++ b/src/scoreinfo.ts
@@ -147,7 +147,7 @@ export class SheetInfoInPage extends SheetInfo {
 export class SheetInfoHtml extends SheetInfo {
     private readonly PAGE_COUNT_REG = /pages(?:&quot;|"):(\d+)/;
     private readonly THUMBNAIL_REG =
-        /<link (?:.*) href="(.*)" rel="preload" as="image"/;
+        /<link[^>]*?href="([^"]+)"[^>]*?rel="preload"[^>]*?as="image"/;
 
     private readonly DIMENSIONS_REG =
         /dimensions(?:&quot;|"):(?:&quot;|")(\d+)x(\d+)(?:&quot;|"),/;


### PR DESCRIPTION
As of this morning, MuseScore has changed the attributes in the `<link>` element for score images, which prevents the `THUMBNAIL_REG` regex from matching.

Here's an example of the new `<link>` element:
```html
<link type="image/svg+xml" href="https://musescore.com/static/musescore/scoredata/g/28254a1e7caeb37d93d6fff5f29eb5e391020465/score_0.svg?no-cache=1743341368" rel="preload" fetchpriority="high" as="image" importance="high">
```

The original regex `/<link (?:.*) href="(.*)" rel="preload" as="image"/` no longer matches this format.
I replaced it with a working and more robust version that would still match in the future if they add new attributes again: `/<link[^>]*?href="([^"]+)"[^>]*?rel="preload"[^>]*?as="image"/`.