### PR TITLE
Basic "unknown image format" error pdf generation handling.

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -73,12 +73,16 @@ export const generatePDF = async (
             imgBlobs.map((b) => readData(b, "dataUrl"))
         );
 
-        imgDataUrlList.forEach((data) => {
-            pdf.addPage();
-            pdf.image(data, {
-                width,
-                height,
-            });
+        imgDataUrlList.forEach((data, idx) => {
+            try {
+                pdf.addPage();
+                pdf.image(data, {
+                    width,
+                    height,
+                });
+            } except (err) {
+                console.warn(`Skipping image #${idx} due to error: ${err.message}`);
+            }
         });
     } else {
         // imgType == "svg"


### PR DESCRIPTION
The script was not working with https://musescore.com/user/98805/scores/2934136

I'm not sure what's going on with the broken page, but this patch at least allows it to work.

Maybe it makes more sense to add this to a CLI flag or similar? Also the SVG loop maybe should be patched as well.