### PR TITLE
Avoid crash if thumbnail type not found

### DIFF
--- a/src/scoreinfo.ts
+++ b/src/scoreinfo.ts
@@ -108,8 +108,9 @@ export abstract class SheetInfo {
 
     get imgType(): "svg" | "png" {
         const thumbnail = this.thumbnailUrl;
-        const imgtype = thumbnail.match(/score_0\.(\w+)/)![1];
-        return imgtype as "svg" | "png";
+        console.log("THUMBNAIL: " + thumbnail)
+        const imgtype = thumbnail.substring(thumbnail.lastIndexOf("."), thumbnail.length);
+        return imgtype;
     }
 }
 


### PR DESCRIPTION
With this, I want to avoid crashing when the thumbnail is not found. I also fixed the extension detection, now not using regexes.