### PR TITLE
fix(cli): Gracefully handle browser-only authentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dl-librescore",
-  "version": "0.35.23",
+  "version": "0.35.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dl-librescore",
-      "version": "0.35.23",
+      "version": "0.35.32",
       "license": "MIT",
       "dependencies": {
         "@librescore/fonts": "^0.4.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -597,55 +597,59 @@ void (async () => {
 
         await Promise.all(
             types.map(async (type) => {
-                // download/generate file data
-                let fileExt: String;
-                let fileData: Buffer;
-                switch (type) {
-                    case "midi": {
-                        fileExt = "mid";
-                        const fileUrl = await getFileUrl(
-                            scoreinfo.id,
-                            "midi",
-                            argv.input
-                        );
-                        fileData = await fetchBuffer(fileUrl);
-                        break;
-                    }
-                    case "mp3": {
-                        fileExt = "mp3";
-                        const fileUrl = await getFileUrl(
-                            scoreinfo.id,
-                            "mp3",
-                            argv.input
-                        );
-                        fileData = await fetchBuffer(fileUrl);
-                        break;
-                    }
-                    case "pdf": {
-                        fileExt = "pdf";
-                        fileData = Buffer.from(
-                            await exportPDF(
-                                scoreinfo,
-                                scoreinfo.sheet,
+                try {
+                    // download/generate file data
+                    let fileExt: String;
+                    let fileData: Buffer;
+                    switch (type) {
+                        case "midi": {
+                            fileExt = "mid";
+                            const fileUrl = await getFileUrl(
+                                scoreinfo.id,
+                                "midi",
                                 argv.input
-                            )
-                        );
-                        break;
+                            );
+                            fileData = await fetchBuffer(fileUrl);
+                            break;
+                        }
+                        case "mp3": {
+                            fileExt = "mp3";
+                            const fileUrl = await getFileUrl(
+                                scoreinfo.id,
+                                "mp3",
+                                argv.input
+                            );
+                            fileData = await fetchBuffer(fileUrl);
+                            break;
+                        }
+                        case "pdf": {
+                            fileExt = "pdf";
+                            fileData = Buffer.from(
+                                await exportPDF(
+                                    scoreinfo,
+                                    scoreinfo.sheet,
+                                    argv.input
+                                )
+                            );
+                            break;
+                        }
                     }
-                }
 
-                // save to filesystem
-                const f = path.join(
-                    argv.output,
-                    `${scoreinfo.fileName}.${fileExt}`
-                );
-                await fs.promises.writeFile(f, fileData);
-                if (argv.verbose) {
-                    spinner.info(
-                        i18next.t("cli_saved_message", {
-                            file: chalk.underline(f),
-                        })
+                    // save to filesystem
+                    const f = path.join(
+                        argv.output,
+                        `${scoreinfo.fileName}.${fileExt}`
                     );
+                    await fs.promises.writeFile(f, fileData);
+                    if (argv.verbose) {
+                        spinner.info(
+                            i18next.t("cli_saved_message", {
+                                file: chalk.underline(f),
+                            })
+                        );
+                    }
+                } catch (e) {
+                    spinner.fail(`Failed to download ${type}: ${e.message}`);
                 }
             })
         );

--- a/src/file.ts
+++ b/src/file.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-extend-native */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 
+import isNode from "detect-node";
 import md5 from "md5";
 import { getFetch } from "./utils";
 import { auths } from "./file-magics";
@@ -18,6 +19,10 @@ const getSuffix = async (scoreUrl: string): Promise<string | null> => {
             ),
         ].map((match) => match[1]);
     } else {
+        if (isNode) {
+            // Cannot get suffix in node without a scoreUrl
+            return null;
+        }
         suffixUrls = [
             ...document.head.innerHTML.matchAll(
                 /link.+?href=["'](https:\/\/musescore\.com\/static\/public\/build\/musescore.*?(?:_es6)?\/20.+?\.js)["']/g
@@ -58,6 +63,9 @@ const getApiAuthNetwork = async (
     type: FileType,
     index: number
 ): Promise<string> => {
+    if (isNode) {
+        throw new Error("getApiAuthNetwork is not supported in Node.js");
+    }
     let numPages = 0;
     let pageCooldown = 25;
     if (!auths[type + index]) {


### PR DESCRIPTION
The CLI was crashing with a `ReferenceError: document is not defined` because it was trying to execute browser-specific code for authentication.

This change introduces an environment check using `detect-node` to prevent browser-only code from running in the Node.js environment.

- In `src/file.ts`, the `getApiAuthNetwork` function now throws an error when called in Node.js, as it relies on browser APIs.
- The `getSuffix` function is also made safe for Node.js execution.
- In `src/cli.ts`, a `try...catch` block is added to the download logic to gracefully handle the error thrown by `getApiAuthNetwork` and other potential download errors. This prevents the application from crashing and provides a user-friendly error message.