### PR TITLE
fix: append extensions to midi and mp3 download filenames

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -119,7 +119,7 @@ const main = (): void => {
                 name: i18next.t("download", { fileType: "MIDI" }),
                 action: BtnAction.download(
                     () => getFileUrl(scoreinfo.id, "midi"),
-                    scoreinfo.fileName,
+                    scoreinfo.fileName + ".mid",
                     fallback,
                     30 * 1000 /* 30s */
                 ),
@@ -129,7 +129,7 @@ const main = (): void => {
                 name: i18next.t("download", { fileType: "MP3" }),
                 action: BtnAction.download(
                     () => getFileUrl(scoreinfo.id, "mp3"),
-                    scoreinfo.fileName,
+                    scoreinfo.fileName + ".mp3",
                     fallback,
                     30 * 1000 /* 30s */
                 ),


### PR DESCRIPTION
## Description

This pull request resolves an issue where downloaded MIDI and MP3 files were saved without their respective file extensions (`.mid` and `.mp3`). 

### The Problem
Previously, in `src/main.ts`, the `BtnAction.download` helper was called with `scoreinfo.fileName` as the target filename parameter for both MIDI and MP3 downloads. Because `scoreinfo.fileName` only returns the sanitized title of the sheet music *without* any file extension, the browser saved these files without an extension (e.g., as `Song_Title` instead of `Song_Title.mid`). 

Unlike PDF downloads (where the `.pdf` extension is explicitly appended during the export process in `src/pdf.ts`), no file extension handling was present for the direct MIDI and MP3 downloads.

### The Solution
We appended the missing `.mid` and `.mp3` file extensions to the filename arguments in the `BtnAction.download` calls in `src/main.ts`:
- Added `+ ".mid"` to the MIDI download button action.
- Added `+ ".mp3"` to the MP3 download button action.

This ensures that the browser automatically saves the files with their correct extensions, preventing users from having to manually rename the downloaded files to open them.

### Changes
In `src/main.ts`:
```diff
@@ -122,3 +122,3 @@
                 action: BtnAction.download(
                     () => getFileUrl(scoreinfo.id, "midi"),
-                    scoreinfo.fileName,
+                    scoreinfo.fileName + ".mid",
                     fallback,
@@ -132,3 +132,3 @@
                 action: BtnAction.download(
                     () => getFileUrl(scoreinfo.id, "mp3"),
-                    scoreinfo.fileName,
+                    scoreinfo.fileName + ".mp3",
                     fallback,