### PR TITLE
fix(img): fix HTTP 422 causing scores to download with missing pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dl-librescore",
-  "version": "0.35.34",
+  "version": "0.35.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dl-librescore",
-      "version": "0.35.34",
+      "version": "0.35.40",
       "license": "MIT",
       "dependencies": {
         "@librescore/fonts": "^0.4.1",

--- a/src/file-magics.ts
+++ b/src/file-magics.ts
@@ -9,6 +9,12 @@ const INDEX_REG = /index=(\d+)/;
 
 export const auths = {};
 
+// Image URLs captured directly from the player's own jmuse API responses.
+// The player always uses a valid token, so its responses give us the real
+// S3 image URL (no token needed) for each page — bypassing MD5/token guessing
+// entirely, which is what breaks (HTTP 422) when MuseScore rotates the scheme.
+export const imgUrls: Record<number, string> = {};
+
 (() => {
     if (isNodeJs) {
         // noop in CLI
@@ -30,6 +36,8 @@ export const auths = {};
                     hookNative(w, "fetch", () => {
                         return function (url, init) {
                             let token = init?.headers?.Authorization;
+                            let capturedType: string | undefined;
+                            let capturedIndex: string | undefined;
                             if (
                                 typeof url === "string" &&
                                 (token || url.match(INIT_PAGE_REG))
@@ -40,11 +48,33 @@ export const auths = {};
                                     const type = m[1];
                                     const index = i[1];
                                     auths[type + index] = token;
+                                    capturedType = type;
+                                    capturedIndex = index;
                                 } else if (url.match(INIT_PAGE_REG)) {
                                     auths["img0"] = url;
                                 }
                             }
-                            return fetch(url, init);
+
+                            const res = fetch(url, init);
+
+                            // For image API calls, read the player's own (valid)
+                            // response and cache the real image URL. This lets us
+                            // skip MD5/token guessing when building the PDF.
+                            if (capturedType === "img" && capturedIndex) {
+                                const idx = Number(capturedIndex);
+                                res.then((r) => r.clone().json())
+                                    .then((data) => {
+                                        const u = data?.info?.url;
+                                        if (typeof u === "string") {
+                                            imgUrls[idx] = u;
+                                        }
+                                    })
+                                    .catch(() => {
+                                        /* ignore: falls back to token path */
+                                    });
+                            }
+
+                            return res;
                         };
                     });
                 }

--- a/src/file.ts
+++ b/src/file.ts
@@ -3,9 +3,41 @@
 
 import md5 from "md5";
 import { getFetch } from "./utils";
-import { auths } from "./file-magics";
+import { auths, imgUrls } from "./file-magics";
 
 export type FileType = "img" | "mp3" | "midi";
+
+/**
+ * Get the image URL for a page directly from the player's own API response
+ * (captured by the fetch hook). The player always uses a valid token, so this
+ * avoids MD5/token guessing — the root cause of HTTP 422 when MuseScore rotates
+ * its auth scheme. Triggers a scroll pass so the player loads every page, then
+ * waits for that page's URL to be captured.
+ */
+const getImgUrlFromPlayer = async (
+    index: number,
+    pageCount?: number
+): Promise<string | null> => {
+    if (imgUrls[index]) {
+        return imgUrls[index];
+    }
+    // Kick off the scroll pass (idempotent) so the player fetches all pages.
+    getApiAuthNetwork("img", index, pageCount).catch(() => undefined);
+
+    const timeoutMs = Math.max((pageCount || 1) * 50 + 2100, 30 * 1000);
+    return new Promise((resolve) => {
+        const start = Date.now();
+        const timer = setInterval(() => {
+            if (imgUrls[index]) {
+                clearInterval(timer);
+                resolve(imgUrls[index]);
+            } else if (Date.now() - start > timeoutMs) {
+                clearInterval(timer);
+                resolve(null);
+            }
+        }, 100);
+    });
+};
 
 const getSuffix = async (
     scoreUrl: string,
@@ -55,15 +87,51 @@ const getApiAuth = async (
     return md5(code).slice(0, 4);
 };
 
-let imgInProgress = false;
+let imgScrollStarted = false;
 
 const getApiAuthNetwork = async (
     type: FileType,
-    index: number
+    index: number,
+    pageCount?: number
 ): Promise<string> => {
     let numPages = 0;
     let pageCooldown = 25;
-    if (!auths[type + index]) {
+
+    // The image scroll pass must run even once a token exists, because the goal
+    // is to make the player load EVERY page (so we can capture each page's real
+    // URL) — not just obtain one token. The `imgScrollStarted` guard keeps it
+    // one-shot. Other types still gate on `!auths` below.
+    if (type === "img") {
+        try {
+            let parentDiv = document.querySelector(
+                "#jmuse-scroller-component"
+            )!;
+            numPages =
+                pageCount && pageCount > 0
+                    ? pageCount
+                    : parentDiv.children.length;
+
+            if (!imgScrollStarted) {
+                imgScrollStarted = true;
+                let i = 0;
+                const scrollToNextChild = () => {
+                    let childDiv = parentDiv.children[i];
+                    if (childDiv) {
+                        childDiv.scrollIntoView();
+                    }
+                    i++;
+                    if (i < parentDiv.children.length) {
+                        setTimeout(scrollToNextChild, pageCooldown);
+                    }
+                };
+                scrollToNextChild();
+            }
+        } catch (err) {
+            console.error(err);
+        }
+    }
+
+    if (type !== "img" && !auths[type + index]) {
         try {
             switch (type) {
                 case "midi": {
@@ -126,34 +194,8 @@ const getApiAuthNetwork = async (
                     }
                     break;
                 }
-                case "img": {
-                    if (!imgInProgress) {
-                        imgInProgress = true;
-                        let parentDiv = document.querySelector(
-                            "#jmuse-scroller-component"
-                        )!;
-
-                        numPages = parentDiv.children.length - 3;
-                        let i = 0;
-
-                        function scrollToNextChild() {
-                            let childDiv = parentDiv.children[i];
-                            if (childDiv) {
-                                childDiv.scrollIntoView();
-                            }
-
-                            i++;
-
-                            if (i < numPages) {
-                                setTimeout(scrollToNextChild, pageCooldown);
-                            }
-                        }
-
-                        scrollToNextChild();
-                    }
-                    imgInProgress = false;
-                    break;
-                }
+                // Note: the "img" scroll pass is handled before this switch,
+                // since it must run even when a token already exists.
             }
         } catch (err) {
             console.error(err);
@@ -168,7 +210,11 @@ const getApiAuthNetwork = async (
                     reject(new Error("token timeout"));
                 },
                 type === "img"
-                    ? numPages * pageCooldown * 2 + 2100
+                    ? // Time for the scroll pass to reach every page (it scrolls
+                      // one page per `pageCooldown`) plus loading slack. Floor at
+                      // 30s so large scores never time out prematurely — the
+                      // cause of downloads stalling partway through.
+                      Math.max(numPages * pageCooldown * 2 + 2100, 30 * 1000)
                     : 5 * 1000 /* 5s */
             );
 
@@ -177,7 +223,9 @@ const getApiAuthNetwork = async (
                 if (auths.hasOwnProperty(type + index)) {
                     clearTimeout(timer);
                     clearInterval(interval);
-                    setInterval(
+                    // one-shot delay (not setInterval, which would leak a timer
+                    // that fires forever) — long for images to let them load
+                    setTimeout(
                         () => {
                             resolve(auths[type + index]);
                         },
@@ -202,12 +250,24 @@ export const getFileUrl = async (
     setText?: (str: string) => void,
     pageCount?: number
 ): Promise<string> => {
-    const url = getApiUrl(id, type, index);
-    let auth = await getApiAuth(id, type, index, scoreUrl);
     if (setText && pageCount) {
         const percent = Math.round(((index + 1) / pageCount) * 83);
         setText(`${percent}%`);
     }
+
+    // Preferred path for images: use the real URL the player already fetched
+    // with a valid token. This bypasses the MD5/token scheme that MuseScore
+    // rotates and that causes HTTP 422 mid-download.
+    if (type === "img") {
+        const playerUrl = await getImgUrlFromPlayer(index, pageCount);
+        if (playerUrl) {
+            return playerUrl;
+        }
+        // else: fall through to the legacy token path below
+    }
+
+    const url = getApiUrl(id, type, index);
+    let auth = await getApiAuth(id, type, index, scoreUrl);
 
     let r = await _fetch(url, {
         headers: {
@@ -224,7 +284,7 @@ export const getFileUrl = async (
         });
 
         if (!r.ok) {
-            auth = await getApiAuthNetwork(type, index);
+            auth = await getApiAuthNetwork(type, index, pageCount);
             if (type === "img" && index === 0) {
                 // auth is the URL for the first page
                 r = await _fetch(auth);


### PR DESCRIPTION
## Problem
When MuseScore rotates its token/MD5 auth scheme, the current
token-guessing approach returns HTTP 422. As a result, downloads stop
partway through and the exported PDF ends up missing pages.

## Fix
Instead of guessing the token, hook the player's own jmuse API responses
(which always use a valid token) to capture the real image URL for each
page, then prefer that URL when building the PDF. If a URL can't be
captured, it automatically falls back to the old token path, so existing
behavior isn't broken.

## Changes
- `file-magics.ts`: add an `imgUrls` cache; read the player's responses
  and store the real per-page image URL.
- `file.ts`: add `getImgUrlFromPlayer()` and prefer it in `getFileUrl()`,
  falling back to the legacy token path when needed.
- Run the scroll pass even when a token already exists, so the player
  loads every page.
- Raise the image token timeout to a 30s floor so large, multi-page
  scores don't time out early.
- Fix a leaking timer: use `setTimeout` instead of `setInterval` for the
  one-shot resolve delay.

## Testing
- Tested on scores that previously failed with 422 → all pages now
  download correctly.