### PR TITLE
Fix/cli cloudflare fallback

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
         "editor.formatOnSave": true
     },
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true
+        "source.fixAll.eslint": "explicit"
     },
     "typescript.tsdk": "node_modules/typescript/lib",
     "i18n-ally.localesPaths": ["src/i18n"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dl-librescore",
-  "version": "0.35.34",
+  "version": "0.35.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dl-librescore",
-      "version": "0.35.34",
+      "version": "0.35.40",
       "license": "MIT",
       "dependencies": {
         "@librescore/fonts": "^0.4.1",
@@ -3383,6 +3383,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3625,6 +3626,7 @@
       "integrity": "sha512-wc2cBWqJgkU3Iz5oztRkQbfVkbxoz5EhnCGOrnJvnLnQ7O0WhQUYyv18qQI79O8L7DdHrrlJNeCHd4VGpnaXKQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.6"
       },
@@ -4272,7 +4274,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/type": {
       "version": "1.2.0",
@@ -4319,6 +4322,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
       "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "ora": "^5.4.1",
         "proxy-agent": "^5.0.0",
         "webmscore": "^1.2.1",
+        "ws": "^8.18.3",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -4491,6 +4492,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xregexp": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "ora": "^5.4.1",
     "proxy-agent": "^5.0.0",
     "webmscore": "^1.2.1",
+    "ws": "^8.18.3",
     "yargs": "^17.7.2"
   },
   "devDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -93,6 +93,7 @@ export default [
     },
     {
         input: "src/cli.ts",
+        external: ["ws"],
         output: {
             file: "dist/cli.js",
             format: "cjs",

--- a/src/browser-fetch.ts
+++ b/src/browser-fetch.ts
@@ -1,0 +1,344 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { spawn, ChildProcess } from "child_process";
+
+// Keep ws external to the CLI bundle so optional native accelerators still work.
+const WebSocketImpl: typeof WebSocket = require("ws");
+
+type CdpResponse = {
+    id?: number;
+    result?: any;
+    error?: { message: string };
+};
+
+type PendingRequest = {
+    resolve: (value: any) => void;
+    reject: (reason: Error) => void;
+};
+
+const findBrowser = (): string => {
+    const candidates = [
+        process.env.CHROME_PATH,
+        process.platform === "win32"
+            ? path.join(
+                  process.env.PROGRAMFILES || "C:\\Program Files",
+                  "Google/Chrome/Application/chrome.exe"
+              )
+            : undefined,
+        process.platform === "win32"
+            ? path.join(
+                  process.env["PROGRAMFILES(X86)"] ||
+                      "C:\\Program Files (x86)",
+                  "Google/Chrome/Application/chrome.exe"
+              )
+            : undefined,
+        process.platform === "win32" && process.env.LOCALAPPDATA
+            ? path.join(
+                  process.env.LOCALAPPDATA,
+                  "Google/Chrome/Application/chrome.exe"
+              )
+            : undefined,
+        process.platform === "win32"
+            ? path.join(
+                  process.env.PROGRAMFILES || "C:\\Program Files",
+                  "Microsoft/Edge/Application/msedge.exe"
+              )
+            : undefined,
+        process.platform === "win32"
+            ? path.join(
+                  process.env["PROGRAMFILES(X86)"] ||
+                      "C:\\Program Files (x86)",
+                  "Microsoft/Edge/Application/msedge.exe"
+              )
+            : undefined,
+        process.platform === "darwin"
+            ? "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+            : undefined,
+        process.platform === "darwin"
+            ? "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge"
+            : undefined,
+        process.platform === "linux" ? "/usr/bin/google-chrome" : undefined,
+        process.platform === "linux"
+            ? "/usr/bin/google-chrome-stable"
+            : undefined,
+        process.platform === "linux" ? "/usr/bin/chromium" : undefined,
+        process.platform === "linux" ? "/usr/bin/chromium-browser" : undefined,
+        process.platform === "linux" ? "/usr/bin/microsoft-edge" : undefined,
+    ];
+
+    const browser = candidates.find(
+        (candidate): candidate is string =>
+            typeof candidate === "string" && fs.existsSync(candidate)
+    );
+    if (!browser) {
+        throw new Error(
+            "MuseScore blocked the direct request and Chrome or Edge was not found. " +
+                "Install one of them or set CHROME_PATH to the browser executable."
+        );
+    }
+    return browser;
+};
+
+class BrowserFetchSession {
+    private readonly pending = new Map<number, PendingRequest>();
+    private nextId = 1;
+    private sessionId = "";
+    private scoreHtml = "";
+
+    private constructor(
+        private readonly browserProcess: ChildProcess,
+        private readonly socket: WebSocket,
+        private readonly scoreUrl: string
+    ) {
+        socket.addEventListener("message", (event) => {
+            const message = JSON.parse(String(event.data)) as CdpResponse;
+            if (!message.id) return;
+            const request = this.pending.get(message.id);
+            if (!request) return;
+            this.pending.delete(message.id);
+            if (message.error) {
+                request.reject(new Error(message.error.message));
+            } else {
+                request.resolve(message.result);
+            }
+        });
+        socket.addEventListener("close", () => {
+            const error = new Error("The browser connection closed unexpectedly");
+            this.pending.forEach(({ reject }) => reject(error));
+            this.pending.clear();
+        });
+    }
+
+    static async launch(url: string): Promise<BrowserFetchSession> {
+        const profileDir = path.join(
+            os.tmpdir(),
+            "dl-librescore-browser-profile-v2"
+        );
+        fs.mkdirSync(profileDir, { recursive: true });
+        // Port 0 makes Chromium expose navigator.webdriver, which causes
+        // Cloudflare's verification to loop. Any normal nonzero port avoids it.
+        const debugPort = 49152 + Math.floor(Math.random() * 16383);
+        const browserProcess = spawn(
+            findBrowser(),
+            [
+                `--remote-debugging-port=${debugPort}`,
+                `--user-data-dir=${profileDir}`,
+                "--no-first-run",
+                "--no-default-browser-check",
+                "--disable-component-update",
+                url,
+            ],
+            { stdio: ["ignore", "ignore", "pipe"] }
+        );
+
+        try {
+            const wsUrl = await new Promise<string>((resolve, reject) => {
+                let stderr = "";
+                const timer = setTimeout(() => {
+                    reject(new Error("Timed out while starting the browser"));
+                }, 15000);
+
+                browserProcess.stderr!.on("data", (chunk: Buffer) => {
+                    stderr += chunk.toString();
+                    const match = stderr.match(/DevTools listening on (ws:\/\/\S+)/);
+                    if (match) {
+                        clearTimeout(timer);
+                        resolve(match[1]);
+                    }
+                });
+                browserProcess.once("error", (error) => {
+                    clearTimeout(timer);
+                    reject(error);
+                });
+                browserProcess.once("exit", (code) => {
+                    clearTimeout(timer);
+                    reject(
+                        new Error(`Browser exited before connecting (${code})`)
+                    );
+                });
+            });
+
+            const socket = new WebSocketImpl(wsUrl);
+            await new Promise<void>((resolve, reject) => {
+                socket.addEventListener("open", () => resolve(), { once: true });
+                socket.addEventListener(
+                    "error",
+                    () => reject(new Error("Could not connect to the browser")),
+                    { once: true }
+                );
+            });
+
+            const browser = new BrowserFetchSession(
+                browserProcess,
+                socket,
+                url
+            );
+            await browser.attachToScoreTab(url);
+            return browser;
+        } catch (error) {
+            browserProcess.kill();
+            throw error;
+        }
+    }
+
+    private send(method: string, params: any = {}, sessionId?: string) {
+        const id = this.nextId++;
+        return new Promise<any>((resolve, reject) => {
+            this.pending.set(id, { resolve, reject });
+            this.socket.send(JSON.stringify({ id, method, params, sessionId }));
+        });
+    }
+
+    private async attachToScoreTab(url: string): Promise<void> {
+        const deadline = Date.now() + 15000;
+        let targetId = "";
+
+        while (!targetId && Date.now() < deadline) {
+            const { targetInfos } = await this.send("Target.getTargets");
+            const target = targetInfos.find(
+                (info: any) =>
+                    info.type === "page" &&
+                    (info.url === url ||
+                        info.url.startsWith("https://musescore.com/"))
+            );
+            targetId = target?.targetId || "";
+            if (!targetId) {
+                await new Promise((resolve) => setTimeout(resolve, 200));
+            }
+        }
+        if (!targetId) throw new Error("Could not find the MuseScore browser tab");
+
+        const attached = await this.send("Target.attachToTarget", {
+            targetId,
+            flatten: true,
+        });
+        this.sessionId = attached.sessionId;
+        await this.send("Runtime.enable", {}, this.sessionId);
+    }
+
+    async waitForScorePage(): Promise<void> {
+        const deadline = Date.now() + 120000;
+        while (Date.now() < deadline) {
+            const result = await this.evaluate(`(() => {
+                const score = window.UGAPP?.store?.page?.data?.score || {};
+                const image = document.querySelector('img[src*="score_0"]');
+                return {
+                    html: document.documentElement?.outerHTML || "",
+                    metadata: {
+                        pagesCount: score.pages_count,
+                        imageWidth: image?.naturalWidth,
+                        imageHeight: image?.naturalHeight
+                    }
+                };
+            })()`);
+            if (/musescore:\/\/score\/\d+/.test(result.html)) {
+                const { pagesCount, imageWidth, imageHeight } = result.metadata;
+                if (pagesCount > 0 && imageWidth > 0 && imageHeight > 0) {
+                    this.scoreHtml =
+                        result.html +
+                        `<script type="application/json">${JSON.stringify({
+                            dimensions: `${imageWidth}x${imageHeight}`,
+                            pages: pagesCount,
+                        })}</script>`;
+                    return;
+                }
+            }
+            await new Promise((resolve) => setTimeout(resolve, 500));
+        }
+        throw new Error(
+            "MuseScore's browser verification did not finish. Complete it in the browser window and try again."
+        );
+    }
+
+    private async evaluate(expression: string): Promise<any> {
+        const { result, exceptionDetails } = await this.send(
+            "Runtime.evaluate",
+            { expression, awaitPromise: true, returnByValue: true },
+            this.sessionId
+        );
+        if (exceptionDetails) {
+            throw new Error(
+                exceptionDetails.exception?.description ||
+                    exceptionDetails.text ||
+                    "Browser evaluation failed"
+            );
+        }
+        return result.value;
+    }
+
+    async fetch(input: RequestInfo, init?: RequestInit): Promise<Response> {
+        const url = typeof input === "string" ? input : input.url;
+        if (
+            url === this.scoreUrl &&
+            (!init?.method || init.method.toUpperCase() === "GET") &&
+            this.scoreHtml
+        ) {
+            return new Response(this.scoreHtml, {
+                headers: { "content-type": "text/html; charset=utf-8" },
+            });
+        }
+        const request = JSON.stringify({
+            url,
+            init: {
+                method: init?.method,
+                headers: init?.headers,
+                body: init?.body,
+            },
+        });
+        const response = await this.evaluate(`(async () => {
+            const request = ${request};
+            const response = await fetch(request.url, request.init);
+            const bytes = new Uint8Array(await response.arrayBuffer());
+            let binary = "";
+            for (let i = 0; i < bytes.length; i += 32768) {
+                binary += String.fromCharCode(...bytes.subarray(i, i + 32768));
+            }
+            return {
+                status: response.status,
+                body: btoa(binary)
+            };
+        })()`);
+        const body = Buffer.from(response.body, "base64");
+        return new Response(body, {
+            status: response.status,
+        });
+    }
+
+    async close(): Promise<void> {
+        try {
+            await this.send("Browser.close");
+        } catch {}
+        this.socket.close();
+        if (this.browserProcess.exitCode === null) {
+            await Promise.race([
+                new Promise<void>((resolve) =>
+                    this.browserProcess.once("exit", () => resolve())
+                ),
+                new Promise<void>((resolve) =>
+                    setTimeout(() => {
+                        this.browserProcess.kill();
+                        resolve();
+                    }, 5000)
+                ),
+            ]);
+        }
+    }
+}
+
+let session: BrowserFetchSession | undefined;
+
+export const getBrowserFetch = async (url: string): Promise<typeof fetch> => {
+    if (!session) {
+        session = await BrowserFetchSession.launch(url);
+        await session.waitForScorePage();
+    }
+    return session.fetch.bind(session) as typeof fetch;
+};
+
+export const closeBrowserFetch = async (): Promise<void> => {
+    if (!session) return;
+    const current = session;
+    session = undefined;
+    await current.close();
+};

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,12 +7,13 @@ import os from "os";
 import { setMscz } from "./mscz";
 import { loadMscore, INDV_DOWNLOADS, WebMscore } from "./mscore";
 import { ScoreInfoHtml, ScoreInfoObj } from "./scoreinfo";
-import { fetchBuffer } from "./utils";
+import { fetchBuffer, getFetch } from "./utils";
 import { isNpx, getVerInfo } from "./npm-data";
 import { getFileUrl } from "./file";
 import { exportPDF } from "./pdf";
 import i18nextInit, { i18next } from "./i18n/index";
 import { InputFileFormat } from "webmscore/schemas";
+import { getBrowserFetch, closeBrowserFetch } from "./browser-fetch";
 
 (async () => {
     await i18nextInit;
@@ -519,7 +520,20 @@ void (async () => {
         }
 
         // request scoreinfo
-        let scoreinfo: ScoreInfoHtml = await ScoreInfoHtml.request(argv.input);
+        let cliFetch = getFetch();
+        let scoreinfo: ScoreInfoHtml = await ScoreInfoHtml.request(
+            argv.input,
+            cliFetch
+        );
+        if (scoreinfo.status === 403) {
+            try {
+                cliFetch = await getBrowserFetch(argv.input);
+                scoreinfo = await ScoreInfoHtml.request(argv.input, cliFetch);
+            } catch (err) {
+                spinner.fail(err instanceof Error ? err.message : String(err));
+                return;
+            }
+        }
 
         // validate musescore URL
         if (scoreinfo.id === 0) {
@@ -606,7 +620,9 @@ void (async () => {
                         const fileUrl = await getFileUrl(
                             scoreinfo.id,
                             "midi",
-                            argv.input
+                            argv.input,
+                            0,
+                            cliFetch
                         );
                         fileData = await fetchBuffer(fileUrl);
                         break;
@@ -616,7 +632,9 @@ void (async () => {
                         const fileUrl = await getFileUrl(
                             scoreinfo.id,
                             "mp3",
-                            argv.input
+                            argv.input,
+                            0,
+                            cliFetch
                         );
                         fileData = await fetchBuffer(fileUrl);
                         break;
@@ -627,7 +645,9 @@ void (async () => {
                             await exportPDF(
                                 scoreinfo,
                                 scoreinfo.sheet,
-                                argv.input
+                                argv.input,
+                                undefined,
+                                cliFetch
                             )
                         );
                         break;
@@ -653,4 +673,4 @@ void (async () => {
         spinner.succeed(i18next.t("cli_done_message"));
         return;
     }
-})();
+})().finally(closeBrowserFetch);

--- a/src/file.ts
+++ b/src/file.ts
@@ -49,9 +49,10 @@ const getApiAuth = async (
     id: number,
     type: FileType,
     index: number,
-    scoreUrl: string
+    scoreUrl: string,
+    _fetch = getFetch()
 ): Promise<string> => {
-    const code = `${id}${type}${index}${await getSuffix(scoreUrl)}`;
+    const code = `${id}${type}${index}${await getSuffix(scoreUrl, _fetch)}`;
     return md5(code).slice(0, 4);
 };
 
@@ -203,7 +204,7 @@ export const getFileUrl = async (
     pageCount?: number
 ): Promise<string> => {
     const url = getApiUrl(id, type, index);
-    let auth = await getApiAuth(id, type, index, scoreUrl);
+    let auth = await getApiAuth(id, type, index, scoreUrl, _fetch);
     if (setText && pageCount) {
         const percent = Math.round(((index + 1) / pageCount) * 83);
         setText(`${percent}%`);

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -3,7 +3,7 @@ import { PDFWorker } from "../dist/cache/worker";
 import { PDFWorkerHelper } from "./worker-helper";
 import { getFileUrl } from "./file";
 import { ScoreInfo, SheetInfo, Dimensions } from "./scoreinfo";
-import { fetchBuffer } from "./utils";
+import { getFetch } from "./utils";
 
 type _ExFn = (
     imgURLs: string[],
@@ -30,8 +30,18 @@ const _exportPDFBrowser: _ExFn = async (
     return pdfArrayBuffer;
 };
 
-const _exportPDFNode: _ExFn = async (imgURLs, imgType, dimensions) => {
-    const imgBufs = await Promise.all(imgURLs.map((url) => fetchBuffer(url)));
+const _exportPDFNode = async (
+    imgURLs: string[],
+    imgType: "svg" | "png",
+    dimensions: Dimensions,
+    _fetch = getFetch()
+): Promise<ArrayBuffer> => {
+    const imgBufs = await Promise.all(
+        imgURLs.map(async (url) => {
+            const response = await _fetch(url);
+            return Buffer.from(await response.arrayBuffer());
+        })
+    );
 
     const { generatePDF } = PDFWorker();
     const pdfArrayBuffer = (await generatePDF(
@@ -48,7 +58,8 @@ export const exportPDF = async (
     scoreinfo: ScoreInfo,
     sheet: SheetInfo,
     scoreUrl = "",
-    setText: (str: string) => void
+    setText?: (str: string) => void,
+    _fetch = getFetch()
 ): Promise<ArrayBuffer> => {
     const imgType = sheet.imgType;
     const pageCount = sheet.pageCount;
@@ -68,7 +79,7 @@ export const exportPDF = async (
                 "img",
                 scoreUrl,
                 i,
-                undefined,
+                _fetch,
                 setText,
                 pageCount
             );
@@ -80,7 +91,7 @@ export const exportPDF = async (
     if (!isNodeJs) {
         return _exportPDFBrowser(...args, setText);
     } else {
-        return _exportPDFNode(...args);
+        return _exportPDFNode(...args, _fetch);
     }
 };
 

--- a/src/scoreinfo.ts
+++ b/src/scoreinfo.ts
@@ -58,7 +58,7 @@ export class ScoreInfoHtml extends ScoreInfo {
     private readonly BASEURL_REG =
         /<meta property="og:image" content="(.+\/)score_.*">/;
 
-    constructor(private html: string) {
+    constructor(private html: string, public readonly status = 200) {
         super();
     }
 
@@ -89,7 +89,7 @@ export class ScoreInfoHtml extends ScoreInfo {
         _fetch = getFetch()
     ): Promise<ScoreInfoHtml> {
         const r = await _fetch(url);
-        if (!r.ok) return new ScoreInfoHtml("");
+        if (!r.ok) return new ScoreInfoHtml("", r.status);
 
         const html = await r.text();
         return new ScoreInfoHtml(html);


### PR DESCRIPTION
## Why

MuseScore can return a Cloudflare HTTP 403 to CLI requests, causing public scores to be reported as “Score not found.” This addresses [#154](https://github.com/LibreScore/dl-librescore/issues/154) and [#155](https://github.com/LibreScore/dl-librescore/issues/155).

## Expected outcome

- Continue using direct HTTP requests when they succeed.
- Fall back to an installed Chrome or Edge browser only after a 403.
- Download MIDI, MP3, and PDF without requiring users to copy cookies or headers manually.

## What changed

The CLI now starts an isolated browser session when MuseScore blocks the initial request. Protected page, API, and PDF image requests run inside that browser context, while MIDI and MP3 files continue downloading directly from the CDN.

The browser uses a nonzero debugging port to avoid exposing `navigator.webdriver`, and is closed automatically when processing finishes.

## What was tested

- [x] `npm ci --dry-run --ignore-scripts`
- [x] `npm run build`
- [x] Downloaded MIDI for score `6582654` and verified the `MThd` header
- [x] Downloaded MP3 for score `6582654` and verified a valid MPEG frame
- [x] Generated a valid three-page PDF for score `6582654`
- [ ] Validate the fallback with Edge, Linux, and macOS browsers